### PR TITLE
Serialize null fields by default

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -48,11 +48,6 @@ impl<'a> ser::SerializeMap for &'a mut Serializer {
         value.serialize(&mut value_serializer)?;
         let val = value_serializer.output;
 
-        if val == "NULL" {
-            self.pending_key = None;
-            return Ok(());
-        }
-
         self.output += "\n";
 
         self.indent();

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -154,7 +154,7 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        self.output += "NULL";
+        self.output += "null";
         Ok(())
     }
 

--- a/src/struct.rs
+++ b/src/struct.rs
@@ -30,10 +30,6 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
         value.serialize(&mut val_serializer)?;
         let val = val_serializer.output;
 
-        if val == "NULL" {
-            return Ok(());
-        }
-
         self.indent();
         key.serialize(&mut key_serializer)?;
         let mut base_key = key_serializer.output;

--- a/src/test.rs
+++ b/src/test.rs
@@ -220,6 +220,7 @@ mod test {
         let expected = concat!(
             "{\n",
             "  a = 32;\n",
+            "  b = null;\n",
             "}",
         );
 
@@ -240,11 +241,41 @@ mod test {
         let expected = concat!(
             "{\n",
             "  1 = 1;\n",
+            "  2 = null;\n",
             "  3 = 3;\n",
             "}",
         );
 
         assert_eq!(none_map_test, expected);
+    }
+
+    #[test]
+    fn skip_serializing_if_none() {
+        #[derive(Serialize)]
+        struct OptionalVals {
+            a: Option<i32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            b: Option<i32>,
+            c: Option<i32>,
+        }
+
+        let none = OptionalVals {
+            a: Some(32),
+            b: None,
+            c: Some(64),
+        };
+
+        let none_test = to_string(&none).unwrap();
+
+        #[rustfmt::skip]
+        let expected = concat!(
+            "{\n",
+            "  a = 32;\n",
+            "  c = 64;\n",
+            "}",
+        );
+
+        assert_eq!(none_test, expected);
     }
 
     #[test]


### PR DESCRIPTION
This PR serializes nullable/unit values as `null` instead of filtering them out.

Helpers like `skip_serializing_if_none` can be used to skip serializing `None` if required, which is in line with how other serde crates (e.g. serde_json) handle nullable types.
