### PR TITLE
Add NixLiteral type for raw Nix expressions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@
 //! it is not as a full featured as other serde implemenatations, but I intend
 //! to change that over time
 mod error;
+mod literal;
 mod map;
 mod path;
 mod seq;
@@ -143,7 +144,8 @@ mod test;
 mod tuple;
 
 pub use error::Error;
-pub use path::{NixPath, NixPathBuf, as_nix_path, as_optional_nix_path};
+pub use literal::{as_literal, as_optional_literal, NixLiteral};
+pub use path::{as_nix_path, as_optional_nix_path, NixPath, NixPathBuf};
 use ser::Serializer;
 
 use serde::Serialize;

--- a/src/literal.rs
+++ b/src/literal.rs
@@ -1,0 +1,149 @@
+use serde::{Serialize, Serializer};
+use std::borrow::Cow;
+
+pub(crate) const TOKEN: &str = "$ser_nix::private::Literal";
+
+/// A raw Nix expression that serializes without quotes.
+///
+/// Use this wrapper type when you want to output a raw Nix expression
+/// (e.g., `pkgs.hello`, `lib.mkForce true`, `builtins.currentSystem`).
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use ser_nix::{to_string, NixLiteral};
+///
+/// #[derive(Serialize)]
+/// struct Config {
+///     package: NixLiteral<'static>,
+/// }
+///
+/// let config = Config {
+///     package: NixLiteral::from("pkgs.hello"),
+/// };
+///
+/// let result = to_string(&config).unwrap();
+/// assert!(result.contains("package = pkgs.hello;"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NixLiteral<'a>(Cow<'a, str>);
+
+impl<'a> NixLiteral<'a> {
+    /// Creates a new `NixLiteral` from a string slice.
+    pub fn new(expr: &'a str) -> Self {
+        NixLiteral(Cow::Borrowed(expr))
+    }
+
+    /// Returns the underlying expression as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Converts into an owned `String`.
+    pub fn into_string(self) -> String {
+        self.0.into_owned()
+    }
+}
+
+impl From<String> for NixLiteral<'static> {
+    fn from(expr: String) -> Self {
+        NixLiteral(Cow::Owned(expr))
+    }
+}
+
+impl<'a> From<&'a str> for NixLiteral<'a> {
+    fn from(expr: &'a str) -> Self {
+        NixLiteral(Cow::Borrowed(expr))
+    }
+}
+
+impl<'a> From<&'a String> for NixLiteral<'a> {
+    fn from(expr: &'a String) -> Self {
+        NixLiteral(Cow::Borrowed(expr.as_str()))
+    }
+}
+
+impl AsRef<str> for NixLiteral<'_> {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+fn serialize_literal<S>(expr: &str, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_newtype_struct(TOKEN, expr)
+}
+
+impl Serialize for NixLiteral<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_literal(&self.0, serializer)
+    }
+}
+
+/// Serialize a string as a raw Nix expression (without quotes).
+///
+/// Use this function with `#[serde(serialize_with = "...")]` to serialize
+/// string fields as raw Nix expressions.
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use ser_nix::to_string;
+///
+/// #[derive(Serialize)]
+/// struct Config {
+///     #[serde(serialize_with = "ser_nix::as_literal")]
+///     package: String,
+/// }
+///
+/// let config = Config {
+///     package: "pkgs.hello".to_string(),
+/// };
+///
+/// let result = to_string(&config).unwrap();
+/// assert!(result.contains("package = pkgs.hello;"));
+/// ```
+pub fn as_literal<S>(value: &str, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serialize_literal(value, serializer)
+}
+
+/// Serialize an `Option<String>` as a raw Nix expression, or null if None.
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use ser_nix::to_string;
+///
+/// #[derive(Serialize)]
+/// struct Config {
+///     #[serde(serialize_with = "ser_nix::as_optional_literal")]
+///     package: Option<String>,
+/// }
+///
+/// let config = Config {
+///     package: Some("pkgs.hello".to_string()),
+/// };
+///
+/// let result = to_string(&config).unwrap();
+/// assert!(result.contains("package = pkgs.hello;"));
+/// ```
+pub fn as_optional_literal<S>(value: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        Some(v) => serialize_literal(v, serializer),
+        None => serializer.serialize_none(),
+    }
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -6,12 +6,12 @@ use std::path::{Component, Path, PathBuf};
 
 pub(crate) const TOKEN: &str = "$ser_nix::private::Path";
 
-/// Internal serializer that emits Nix path literals (unquoted paths).
-pub(crate) struct PathLitEmitter<'a> {
+/// Internal serializer that emits raw strings without quoting.
+pub(crate) struct RawEmitter<'a> {
     pub output: &'a mut String,
 }
 
-impl ser::Serializer for PathLitEmitter<'_> {
+impl ser::Serializer for RawEmitter<'_> {
     type Ok = ();
     type Error = Error;
     type SerializeSeq = ser::Impossible<(), Error>;
@@ -28,79 +28,79 @@ impl ser::Serializer for PathLitEmitter<'_> {
     }
 
     fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_some<T: ?Sized + Serialize>(self, _value: &T) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_unit_variant(
@@ -109,7 +109,7 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _variant_index: u32,
         _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_newtype_struct<T: ?Sized + Serialize>(
@@ -117,7 +117,7 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_newtype_variant<T: ?Sized + Serialize>(
@@ -127,15 +127,15 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _variant: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_tuple_struct(
@@ -143,7 +143,7 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_tuple_variant(
@@ -153,11 +153,11 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_struct(
@@ -165,7 +165,7 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 
     fn serialize_struct_variant(
@@ -175,7 +175,7 @@ impl ser::Serializer for PathLitEmitter<'_> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Err(ser::Error::custom("expected Path"))
+        Err(ser::Error::custom("expected string"))
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -190,9 +190,9 @@ impl ser::Serializer for &mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        if name == crate::path::TOKEN {
-            use crate::path::PathLitEmitter;
-            let emitter = PathLitEmitter {
+        if name == crate::path::TOKEN || name == crate::literal::TOKEN {
+            use crate::path::RawEmitter;
+            let emitter = RawEmitter {
                 output: &mut self.output,
             };
             return value.serialize(emitter);


### PR DESCRIPTION
Adds support for serializing raw Nix expressions without quotes, similar to NixPath but for arbitrary expressions like `pkgs.hello` or `lib.mkForce true`.

- Add literal.rs module with NixLiteral wrapper type
- Add as_literal and as_optional_literal helper functions
- Update ser.rs to handle literal token