### PR TITLE
fix: quote map keys that are not valid Nix identifiers

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -3,6 +3,20 @@ use super::ser::Serializer;
 
 use serde::{Serialize, ser};
 
+/// Returns `true` if `s` is a valid Nix identifier that can appear unquoted
+/// as an attribute name (e.g. `foo`, `build-inputs`, `x86_64-linux`).
+///
+/// Keys that are not valid identifiers (e.g. `8080/tcp`, `/var/data`) must
+/// remain quoted in Nix attribute sets.
+fn is_nix_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '\'')
+}
+
 impl ser::SerializeMap for &mut Serializer {
     type Ok = ();
     type Error = Error;
@@ -19,14 +33,15 @@ impl ser::SerializeMap for &mut Serializer {
         key.serialize(&mut key_serializer)?;
         let mut base_key = key_serializer.output;
 
-        // TODO: Add cases where keys need to be escaped
-        if true {
-            let try_strip = base_key
-                .strip_prefix("\"")
-                .and_then(|s| s.strip_suffix("\""));
-
-            if let Some(str) = try_strip {
-                base_key = str.to_string()
+        // Only strip quotes from keys that are valid Nix identifiers.
+        // Keys like "8080/tcp" must remain quoted because they contain
+        // characters not allowed in bare Nix attribute names.
+        if let Some(stripped) = base_key
+            .strip_prefix("\"")
+            .and_then(|s| s.strip_suffix("\""))
+        {
+            if is_nix_identifier(stripped) {
+                base_key = stripped.to_string();
             }
         }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -470,6 +470,59 @@ mod test {
     }
 
     #[test]
+    fn map_keys_that_are_valid_identifiers_are_unquoted() {
+        let map: IndexMap<String, bool> = [
+            ("enable", true),
+            ("with-setting", true),
+            ("_private", false),
+        ]
+        .iter()
+        .map(|(a, b)| (a.to_string(), *b))
+        .collect();
+
+        let map_str = to_string(&map).unwrap();
+
+        #[rustfmt::skip]
+        let expected = concat!(
+            "{\n",
+            "  enable = true;\n",
+            "  with-setting = true;\n",
+            "  _private = false;\n",
+            "}"
+        );
+
+        assert_eq!(map_str, expected);
+    }
+
+    #[test]
+    fn map_keys_that_are_not_valid_identifiers_are_quoted() {
+        let map: IndexMap<String, IndexMap<(), ()>> = [
+            ("8080/tcp", IndexMap::new()),
+            ("/var/data", IndexMap::new()),
+            ("key with spaces", IndexMap::new()),
+        ]
+        .iter()
+        .map(|(a, b)| (a.to_string(), b.clone()))
+        .collect();
+
+        let map_str = to_string(&map).unwrap();
+
+        #[rustfmt::skip]
+        let expected = concat!(
+            "{\n",
+            "  \"8080/tcp\" = {\n",
+            "  };\n",
+            "  \"/var/data\" = {\n",
+            "  };\n",
+            "  \"key with spaces\" = {\n",
+            "  };\n",
+            "}"
+        );
+
+        assert_eq!(map_str, expected);
+    }
+
+    #[test]
     fn newtype_var() {
         #[derive(Serialize)]
         enum Test {


### PR DESCRIPTION
Previously, all map keys had their quotes unconditionally stripped. This produced invalid Nix for keys like `8080/tcp` or `/var/data` which are not valid Nix identifiers and must remain quoted in attribute sets.

Now, quotes are only stripped when the key matches the Nix identifier pattern `[a-zA-Z_][a-zA-Z0-9_'-]*`. Keys that don't match (e.g. containing `/`, spaces, or starting with digits) keep their quotes.